### PR TITLE
Alternative fix + extras

### DIFF
--- a/7a_nwis_munge/src/munge_reservoir_data.R
+++ b/7a_nwis_munge/src/munge_reservoir_data.R
@@ -48,7 +48,8 @@ munge_nwis_temperature <- function(in_ind, out_ind, xwalk){
     # but still want to preserve actual depth
     mutate(depth_category = mean(depth, na.rm = TRUE)) %>% # create a single depth per sensor per day
     ungroup() %>%
-    dplyr::select(date, dateTime, timezone, depth, depth_category, temp = value, site_id, source_id = site_no)
+    dplyr::select(date, dateTime, timezone, depth, depth_category, temp = value, site_id, source_id = site_no) %>%
+    filter(temp >= 0 & temp <=40)
 
   saveRDS(dat_out, as_data_file(out_ind))
   gd_put(out_ind)

--- a/7b_temp_merge/out/drb_daily_reservoir_temps.rds.ind
+++ b/7b_temp_merge/out/drb_daily_reservoir_temps.rds.ind
@@ -1,2 +1,2 @@
-hash: 16bbc91e877af05dbdf1a710a2820943
+hash: 17b34b1ad71ed6c8de9744ef7214d733
 

--- a/7b_temp_merge/src/merge_all_temp_dat.R
+++ b/7b_temp_merge/src/merge_all_temp_dat.R
@@ -285,7 +285,8 @@ reduce_reservoir_data <- function(outind, drb_ind, nyc_dep_ind) {
            time_hm = lubridate::hm(time),
            hours_minus_noon = time_hm$hour - 12,
            minutes_decimal = time_hm$minute/60,
-           hours_diff_noon = abs(hours_minus_noon + minutes_decimal)) %>% arrange(site_id, date, depth_category)
+           hours_diff_noon = abs(hours_minus_noon + minutes_decimal)) %>%
+    arrange(site_id, date, depth_category)
 
   nyc_dep_reservoirs_temps <- readRDS(sc_retrieve(nyc_dep_ind))
 
@@ -293,6 +294,7 @@ reduce_reservoir_data <- function(outind, drb_ind, nyc_dep_ind) {
   cannonsville_dates <- unique(nyc_dep_reservoirs_temps$date[nyc_dep_reservoirs_temps$site_id == 'nhdhr_120022743'])
   pepacton_dates <- unique(nyc_dep_reservoirs_temps$date[nyc_dep_reservoirs_temps$site_id == 'nhdhr_151957878'])
 
+  # filter out site-dates that are already accounted for in the NYC DEP data
   daily_drb_dat <- drb_reservoirs_temps %>%
     filter(!(site_id %in% 'nhdhr_120022743' & date %in% cannonsville_dates) &
              !(site_id %in% 'nhdhr_151957878' & date %in% pepacton_dates)) %>%
@@ -301,18 +303,9 @@ reduce_reservoir_data <- function(outind, drb_ind, nyc_dep_ind) {
     ungroup() %>%
     dplyr::select(site_id, source_id, date, depth, temp)
 
-
   combine_dat <- bind_rows('nwis' = daily_drb_dat,
                            'nyc_dep' = nyc_dep_reservoirs_temps, .id = 'source') %>%
-    dplyr::select(site_id, date, dateTime, source_id, source, depth, temp) %>%
-    group_by(site_id, date, source_id, source, depth) %>%
-    summarize(temp_new = mean(temp)) %>%
-    ungroup()
-
-  duplicate_depth <- combine_dat %>%
-    group_by(site_id, date, depth) %>%
-    summarize(n_duplicates = n())
-
+    dplyr::select(site_id, date, source_id, source, depth, temp)
 
   saveRDS(combine_dat, as_data_file(outind))
   gd_put(outind)

--- a/build/status/N2Ffbndpc19tdW5nZS9vdXQvTllDX0RFUF9yZXNlcnZvaXJfdGVtcGVyYXR1cmVfZGF0YS5yZHMuaW5k.yml
+++ b/build/status/N2Ffbndpc19tdW5nZS9vdXQvTllDX0RFUF9yZXNlcnZvaXJfdGVtcGVyYXR1cmVfZGF0YS5yZHMuaW5k.yml
@@ -2,11 +2,11 @@ version: 0.3.0
 name: 7a_nwis_munge/out/NYC_DEP_reservoir_temperature_data.rds.ind
 type: file
 hash: 979466c33dad94437f87680180d73a7c
-time: 2021-04-30 19:48:31 UTC
+time: 2021-05-12 18:33:54 UTC
 depends:
   7a_nwis_munge/in/NYC_DEP_reservoir_data.xlsx.ind: c4cf3a6289414e953ccacf646f6fbfc3
 fixed: ebd35b1cc17cf3a7330c45be93a5ff16
 code:
   functions:
-    munge_nyc_dep_temperature: 4bafe5f0c49648f2da5fb58e6a31f3fa
+    munge_nyc_dep_temperature: db5539a441989334e85c9db4db40f6be
 

--- a/build/status/N2Ffbndpc19tdW5nZS9vdXQvZHJiX3Jlc2Vydm9pcnNfdGVtcF9tdW5nZWQucmRzLmluZA.yml
+++ b/build/status/N2Ffbndpc19tdW5nZS9vdXQvZHJiX3Jlc2Vydm9pcnNfdGVtcF9tdW5nZWQucmRzLmluZA.yml
@@ -2,11 +2,11 @@ version: 0.3.0
 name: 7a_nwis_munge/out/drb_reservoirs_temp_munged.rds.ind
 type: file
 hash: e7da4aca9bedbd98e99971994ccf80f3
-time: 2021-01-15 15:46:52 UTC
+time: 2021-05-12 18:38:12 UTC
 depends:
   6_nwis_fetch/out/drb_reservoirs_temps.rds.ind: 290de56a60a6af713ac3c12149e52e20
 fixed: 59af19820fbf8ff4c60ce450d0af17dc
 code:
   functions:
-    munge_nwis_temperature: 2dfc1172d7f8d3ddd5f7f3aba1dab739
+    munge_nwis_temperature: 63d33880f3aa8b19c8ab7fb496a6304c
 

--- a/build/status/N2JfdGVtcF9tZXJnZS9vdXQvZHJiX2RhaWx5X3Jlc2Vydm9pcl90ZW1wcy5yZHMuaW5k.yml
+++ b/build/status/N2JfdGVtcF9tZXJnZS9vdXQvZHJiX2RhaWx5X3Jlc2Vydm9pcl90ZW1wcy5yZHMuaW5k.yml
@@ -1,13 +1,13 @@
 version: 0.3.0
 name: 7b_temp_merge/out/drb_daily_reservoir_temps.rds.ind
 type: file
-hash: 7fd69d23ac0c5688632f526e875d3bc4
-time: 2021-05-12 14:45:25 UTC
+hash: 12d6a6fd6573a23f779c30656d8bcb40
+time: 2021-05-12 18:46:52 UTC
 depends:
   7a_nwis_munge/out/drb_reservoirs_temp_munged.rds.ind: e7da4aca9bedbd98e99971994ccf80f3
   7a_nwis_munge/out/NYC_DEP_reservoir_temperature_data.rds.ind: 979466c33dad94437f87680180d73a7c
 fixed: 5d2d38007a165b8836954705dbf2a316
 code:
   functions:
-    reduce_reservoir_data: fc4e8034822e90d1650d91b8012c5d6a
+    reduce_reservoir_data: 52f0b361128bcd66c4bd620e9ac344fe
 


### PR DESCRIPTION
Rasha - I decided to tackle the problem at the root. We weren't accounting for minutes, so multiple profiles per hour would have diff from noon. Accounting for minutes selects the true closest to noon profile. Added your group_by and mean at the end because there were still a few repeated depths per profile. 

I also filtered the NWIS temp data to be within 0-40 deg, and filtered out negative depths.